### PR TITLE
Fix build on FreeBSD with clang compiler

### DIFF
--- a/agent/core/CMakeLists.txt
+++ b/agent/core/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories(
 
 find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
-#find_library(DL dl REQUIRED)
 
 aux_source_directory(src SOURCES_BASE)
 aux_source_directory(src/network SOURCES_NETWORK)

--- a/agent/core/CMakeLists.txt
+++ b/agent/core/CMakeLists.txt
@@ -1,5 +1,14 @@
 cmake_minimum_required(VERSION 2.8)
 project(vikki_agent_core)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+	include_directories("/usr/local/include")
+	link_directories("/usr/local/lib")
+endif()
+
 include_directories(
     include
     include/network
@@ -12,9 +21,14 @@ include_directories(
     include/asio/ip/detail
     include/asio/generic/detail
     include/asio/local/detail)
+
+find_package(Threads REQUIRED)
+find_package(OpenSSL REQUIRED)
+#find_library(DL dl REQUIRED)
+
 aux_source_directory(src SOURCES_BASE)
 aux_source_directory(src/network SOURCES_NETWORK)
+
 add_executable(vikki-agent ${SOURCES_BASE} ${SOURCES_NETWORK})
-set(CMAKE_CXX_FLAGS "-pthread -std=c++11")
-target_link_libraries(vikki-agent dl pthread ssl crypto)
+target_link_libraries(vikki-agent ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
 install(TARGETS vikki-agent DESTINATION bin/vikki)

--- a/agent/sensors/load_average_sensor/CMakeLists.txt
+++ b/agent/sensors/load_average_sensor/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 2.8)
 project(load_average_sensor)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+	include_directories("/usr/local/include")
+	link_directories("/usr/local/lib")
+endif()
+
 include_directories(
     include
     ../../core/include)
+
 aux_source_directory(../../core/src SOURCES_BASE)
 aux_source_directory(src SOURCES)
 add_library(load_average_sensor SHARED ${SOURCES_BASE} ${SOURCES})
-set(CMAKE_CXX_FLAGS "-std=c++11")
 install(TARGETS load_average_sensor DESTINATION bin/vikki/sensors)

--- a/agent/sensors/load_average_sensor/src/load_average_sensor.cpp
+++ b/agent/sensors/load_average_sensor/src/load_average_sensor.cpp
@@ -30,6 +30,9 @@ SOFTWARE.
 #include <unistd.h>
 #include <string.h>
 
+#include <cstdlib>
+#include <cerrno>
+
 namespace vikki
 {
 	load_average_sensor::load_average_sensor()

--- a/agent/sensors/memory_usage_sensor/CMakeLists.txt
+++ b/agent/sensors/memory_usage_sensor/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(memory_usage_sensor)
 
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 	include_directories("/usr/local/include")

--- a/agent/sensors/memory_usage_sensor/CMakeLists.txt
+++ b/agent/sensors/memory_usage_sensor/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 2.8)
 project(memory_usage_sensor)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+	include_directories("/usr/local/include")
+	link_directories("/usr/local/lib")
+endif()
+
 include_directories(
     include
     ../../core/include)
+
 aux_source_directory(../../core/src SOURCES_BASE)
 aux_source_directory(src SOURCES)
 add_library(memory_usage_sensor SHARED ${SOURCES_BASE} ${SOURCES})
-set(CMAKE_CXX_FLAGS "-std=c++11")
 install(TARGETS memory_usage_sensor DESTINATION bin/vikki/sensors)

--- a/agent/sensors/memory_usage_sensor/src/memory_usage_sensor.cpp
+++ b/agent/sensors/memory_usage_sensor/src/memory_usage_sensor.cpp
@@ -30,6 +30,9 @@ SOFTWARE.
 #include <unistd.h>
 #include <string.h>
 
+#include <cstdlib>
+#include <cerrno>
+
 namespace vikki
 {
 	memory_usage_sensor::memory_usage_sensor()

--- a/agent/storages/postgresql_storage/CMakeLists.txt
+++ b/agent/storages/postgresql_storage/CMakeLists.txt
@@ -1,12 +1,22 @@
 cmake_minimum_required(VERSION 2.8)
 project(postgresql_storage)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+	include_directories("/usr/local/include")
+	link_directories("/usr/local/lib")
+endif()
+
 include_directories(
     include
     ../../core/include)
+
 aux_source_directory(../../core/src SOURCES_BASE)
 aux_source_directory(src SOURCES)
+
 add_library(postgresql_storage SHARED ${SOURCES_BASE} ${SOURCES})
-set(CMAKE_CXX_FLAGS "-std=c++11")
 find_package(PostgreSQL REQUIRED)
 include_directories(${PostgreSQL_INCLUDE_DIRS})
 target_link_libraries(postgresql_storage ${PostgreSQL_LIBRARIES})


### PR DESCRIPTION
1. Fix lib and include search paths.
2. Convert hard-coded "dl pthread ssl crypto" in target_link_libraries to use founded packages in system.
3. Add requirement of C++11 compatible compiler.
